### PR TITLE
fix: unblock docker action backend install step

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,6 +10,7 @@ jobs:
   # Zuerst: Build testen, damit bei Fehlern die genaue Meldung sichtbar ist
   verify-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,13 +23,15 @@ jobs:
       - name: Install and build frontend
         run: |
           cd frontend
-          npm install
+          npm install --no-audit --no-fund
           npm run build
 
       - name: Install and build backend
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
         run: |
           cd backend
-          npm install
+          npm install --no-audit --no-fund
           npm run build
 
   build-and-push:
@@ -59,6 +62,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            PUPPETEER_SKIP_DOWNLOAD=true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/notenest:latest
             ${{ secrets.DOCKER_USERNAME }}/notenest:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN npm run build
 
 # Stage 2: Backend Build
 FROM node:20-alpine AS backend-builder
+ARG PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_DOWNLOAD=${PUPPETEER_SKIP_DOWNLOAD}
 WORKDIR /app/backend
 COPY backend/package*.json ./
 # Verwende npm install (lock file könnte nicht synchron sein)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM node:18-alpine
 
+ARG PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_DOWNLOAD=${PUPPETEER_SKIP_DOWNLOAD}
+
 WORKDIR /app
 
 # Installiere Build-Dependencies für better-sqlite3 und Puppeteer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and container build changes only; main risk is unintentionally skipping a needed Puppeteer/Chromium download, which would surface as build/runtime failures.
> 
> **Overview**
> Unblocks the GitHub Actions Docker pipeline by **skipping Puppeteer’s Chromium download** during the backend install/build, both in the `verify-build` job and in the Docker `build-and-push` step via `PUPPETEER_SKIP_DOWNLOAD` build args.
> 
> Hardens CI reliability by adding a `timeout-minutes: 30` to the build verification job and using `npm install --no-audit --no-fund` for frontend/backend installs. Dockerfiles are updated to accept/propagate `PUPPETEER_SKIP_DOWNLOAD` (including `Dockerfile.dev`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bf019cce9f788005097508f62066ab80d244e1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->